### PR TITLE
casper-node: removeReferencesTo cargo

### DIFF
--- a/pkgs/casper-node/2.nix
+++ b/pkgs/casper-node/2.nix
@@ -4,6 +4,8 @@
 , cmake
 , pkg-config
 , openssl
+, removeReferencesTo
+, cargo
 }:
 rustPlatform.buildRustPackage {
   pname = "casper-node";
@@ -19,10 +21,14 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-8EwV9n5FbjruG88nl1SKhgmm7wbYoZFQwlMe9K7KWzI=";
 
-  nativeBuildInputs = [ pkg-config cmake ];
+  nativeBuildInputs = [ pkg-config cmake removeReferencesTo ];
   buildInputs = [ openssl.dev ];
 
   doCheck = false;
+
+  postInstall = ''
+    find "$out" -type f -exec remove-references-to -t ${cargo} '{}' +
+  '';
 
   meta = with lib; {
     description = "Reference node for the Casper Blockchain Protocol.";

--- a/pkgs/casper-node/default.nix
+++ b/pkgs/casper-node/default.nix
@@ -4,6 +4,8 @@
 , cmake
 , pkg-config
 , openssl
+, removeReferencesTo
+, cargo
 }:
 rustPlatform.buildRustPackage rec {
   pname = "casper-node";
@@ -18,10 +20,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-AbxeP9GRH8lQsHwYiErh/SaAqu1dvTcwaasL0v7xCoU=";
 
-  nativeBuildInputs = [ pkg-config cmake ];
+  nativeBuildInputs = [ pkg-config cmake removeReferencesTo ];
   buildInputs = [ openssl.dev ];
 
   doCheck = false;
+
+  postInstall = ''
+    find "$out" -type f -exec remove-references-to -t ${cargo} '{}' +
+  '';
 
   meta = with lib; {
     description = "Reference node for the Casper Blockchain Protocol.";


### PR DESCRIPTION
For some reason nix assumes cargo being a runtime dependency of the node. This removes cargo as being a runtime dep.